### PR TITLE
Added lockfile to coprocessor flashing

### DIFF
--- a/co-processor/app/flash.sh
+++ b/co-processor/app/flash.sh
@@ -2,7 +2,15 @@
 
 FW=$1
 REV=$2
-echo "Opening screen terminal for flashing $FW to balenaFin v$REV"
+
+# Makes sure we exit if lock fails.
+set -e
+
+echo "acquiring lockfile..."
+exec {lock_fd}>/tmp/balena/updates.lock || exit 1
+flock -n "$lock_fd" || { echo "ERROR: failed to acquire lockfile." >&2; rm -f /tmp/balena/updates.lock; exit 1; }
+
+echo "opening screen terminal for flashing $FW to balenaFin v$REV"
 case $REV in
   09)
     screen -dmS swd_program  "./openocd/openocd-v1.0.sh"
@@ -12,13 +20,15 @@ case $REV in
     ;;
   *)
     echo "ERROR: unknown balenaFin revision" >&2
+    flock -u "$lock_fd"; rm -f /tmp/balena/updates.lock
     exit 1
     ;;
 esac
 sleep 6
-  { sleep 5; echo "reset halt"; echo "program firmware/bootloader.s37"; sleep 5; echo "reset halt"; echo "program firmware/$FW"; echo "reset run"; sleep 10; } | telnet localhost 4444
+  { sleep 5; echo "reset halt"; echo "program firmware/bootloader.s37"; sleep 5; echo "reset halt"; echo "program firmware/$FW"; echo "reset run"; sleep 10; echo "exit"; echo -e '\x1dclose\x0d'; } | telnet localhost 4444
 sleep 5
+echo -e "flashing complete\n"
+echo "releasing lockfile..."
+flock -u "$lock_fd"; rm -f /tmp/balena/updates.lock
 echo "closing the openocd process..."
 kill $(ps aux | grep '[S]CREEN -dmS swd_program' | awk '{print $2}')
-sleep 5
-echo "flashing complete"


### PR DESCRIPTION
Lockfile prevents supervisor from interrupting coprocessor flashing. 

Additionally fixes issues with gracefully exiting openocd and telnet; previously killing screen process failed to exit script cleanly.

Change-type: minor
Signed-off-by: Alex Bucknall <alexbucknall@balena.io>