### PR TITLE
Corrected docs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ default port: `1337`
 
 ##### flash firmware
 
-_POST_ `/v1/flash/firmware`
+_POST_ `/v1/flash/:firmware`
 
-flashes the given firmware name from the service fs ( ie `firmware/firmata-balena-0.0.2.hex` ). The co-processor service has a volume (`/data`) that you can add to other service and use as a way to share different firmwares to flash. on balenaFin v1.1 and above, this action will trigger a reboot.
+flashes the given firmware name from the service fs ( ie `firmata-balena-0.0.2.hex` ). The co-processor service has a volume (`/data`) that you can add to other service and use as a way to share different firmwares to flash. on balenaFin v1.1 and above, this action will trigger a reboot.
 
 ##### sleep
 


### PR DESCRIPTION
Tweaks wording of v1/flash/:firmware endpoint to make this clear that it is variable.

Change-type: minor
Signed-off-by: Alex Bucknall <alexbucknall@balena.io>